### PR TITLE
MGMT-23103: Update private-api BSR dependency to v0.0.44

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -25,7 +25,7 @@ managed:
 inputs:
 
 - module: buf.build/osac-project/fulfillment-api:v0.0.34
-- module: buf.build/osac-project/private-api:v0.0.43
+- module: buf.build/osac-project/private-api:v0.0.44
 
 plugins:
 


### PR DESCRIPTION
## Summary

Bumps the fulfillment-service private API BSR module (`buf.build/osac-project/private-api`) from v0.0.43 to v0.0.44 in `buf.gen.yaml`.

v0.0.44 corresponds to the merged fulfillment-service [PR #309](https://github.com/osac-project/fulfillment-service/pull/309), which added `addExplicitFields()` to map `ComputeInstanceSpec` explicit fields to the Kubernetes CR. The proto definitions themselves are unchanged between v0.0.43 and v0.0.44, so there are no generated code changes — only the version reference is updated.

## Testing

Build passes: `go build -v ./...`

## Ticket

[MGMT-23103](https://issues.redhat.com/browse/MGMT-23103)

<br>
<br>

<sub>Assisted-by: Claude</sub>