### PR TITLE
MGMT-23354: Add archive notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# **ARCHIVED - This project is now read-only.**
+
+All content has been moved to the [fulfillment-service](https://github.com/osac-project/fulfillment-service)
+project. Please refer to that repository for the latest sources and documentation. No further changes will be
+accepted here.
+
+---
+
 # public_template
 
 Use this repository as the template for public-facing repositories. Please keep the following warning at the top of the repository README:


### PR DESCRIPTION
This patch adds to the `README.md` file a notice explaining that the project has been archived.

Related: https://issues.redhat.com/browse/MGMT-23354